### PR TITLE
Trying to add keyboard interactive functionality

### DIFF
--- a/examples/client_kbdint_auth.pl
+++ b/examples/client_kbdint_auth.pl
@@ -46,7 +46,7 @@ while ($ret == SSH_AUTH_INFO) {
 			$answer .= "\0";
 		}
 		if ($session->auth_kbdint_setanswer(index => $i, answer => $answer) < 0) {
-			print "== attempt to set answer to challenge failed\n";
+			printf("setting answer issue: %s\n", $session->error());
 			exit(1);
 		}
 	}

--- a/examples/client_kbdint_auth.pl
+++ b/examples/client_kbdint_auth.pl
@@ -1,0 +1,65 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use Libssh::Session qw(:all);
+
+my $ssh_host = "127.0.0.1";
+my $ssh_port = 22;
+my $ssh_user = "root";
+my $ssh_pass = "centreon";
+
+my $session = Libssh::Session->new();
+if ($session->options(host => $ssh_host, port => $ssh_port, user => $ssh_user) != SSH_OK) {
+    print $session->error() . "\n";
+    exit(1);
+}
+
+if ($session->connect() != SSH_OK) {
+    print $session->error() . "\n";
+    exit(1);
+}
+
+$session->auth_none(); # prerequisite for getting auth_list
+unless ($session->auth_list() & SSH_AUTH_METHOD_INTERACTIVE) {
+	print "SSH server doesn't support keyboard-interactive authentication.\n";
+	exit(1);
+}
+
+my $ret = $session->auth_kbdint();
+while ($ret == SSH_AUTH_INFO) {
+	my $name        = $session->auth_kbdint_getname();
+	my $instruction = $session->auth_kbdint_getinstruction();
+	my $nprompts    = $session->auth_kbdint_getnprmopts();
+
+	print "$name\n" if ($name);
+	print "$instruction\n" if ($instruction);
+
+	for (my $i = 0; $i < $nprompts; $i++) {
+		my $answer;
+		my $prompt = $session->auth_kbdint_getprompt(index => $i);
+		if ($prompt =~ /Password:/) {
+			$answer = $ssh_pass;
+		} else {
+			print "$prompt ";
+			chomp($answer = <STDIN>);
+			$answer .= "\0";
+		}
+		if ($session->auth_kbdint_setanswer(index => $i, answer => $answer) < 0) {
+			print "== attempt to set answer to challenge failed\n";
+			exit(1);
+		}
+	}
+	$ret = $session->auth_kbdint();
+}
+
+if ($ret == SSH_AUTH_SUCCESS) {
+	print "== authentification succeeded\n";
+} else {
+	my $error = $session->error();
+	print "$error\n" if ($error);
+	print "== failed to authenticate: rc = $ret\n";
+	exit(1);
+}
+
+exit(0);

--- a/examples/client_kbdint_auth.pl
+++ b/examples/client_kbdint_auth.pl
@@ -38,10 +38,10 @@ while ($ret == SSH_AUTH_INFO) {
 	for (my $i = 0; $i < $nprompts; $i++) {
 		my $answer;
 		my $prompt = $session->auth_kbdint_getprompt(index => $i);
-		if ($prompt =~ /Password:/) {
+		if ($prompt->{text} =~ /Password:/) {
 			$answer = $ssh_pass;
 		} else {
-			print "$prompt ";
+			print "$prompt " if ($prompt->{echo});
 			chomp($answer = <STDIN>);
 			$answer .= "\0";
 		}

--- a/examples/client_kbdint_auth.pl
+++ b/examples/client_kbdint_auth.pl
@@ -6,8 +6,8 @@ use Libssh::Session qw(:all);
 
 my $ssh_host = "127.0.0.1";
 my $ssh_port = 22;
-my $ssh_user = "root";
-my $ssh_pass = "centreon";
+my $ssh_user = "sshtest";
+my $ssh_pass = "libsshtest";
 
 my $session = Libssh::Session->new();
 if ($session->options(host => $ssh_host, port => $ssh_port, user => $ssh_user) != SSH_OK) {
@@ -32,8 +32,8 @@ while ($ret == SSH_AUTH_INFO) {
 	my $instruction = $session->auth_kbdint_getinstruction();
 	my $nprompts    = $session->auth_kbdint_getnprmopts();
 
-	print "$name\n" if ($name);
-	print "$instruction\n" if ($instruction);
+	print "$name\n"        if (defined $name);
+	print "$instruction\n" if (defined $instruction);
 
 	for (my $i = 0; $i < $nprompts; $i++) {
 		my $answer;

--- a/lib/Libssh/Session.pm
+++ b/lib/Libssh/Session.pm
@@ -910,6 +910,51 @@ C<OPTIONS> are passed in a hash like fashion, using key and value pairs. Possibl
 B<password> - passphrase for the private key (if it's needed. Otherwise don't set the option).
 
 
+=item auth_kbdint ([ OPTIONS ])
+
+Try to authenticate through the "keyboard-interactive" method. Returns one of the following:
+SSH_AUTH_ERROR:   A serious error happened\n
+SSH_AUTH_DENIED:  Authentication failed : use another method\n
+SSH_AUTH_PARTIAL: You've been partially authenticated, you still
+                  have to use another method\n
+SSH_AUTH_SUCCESS: Authentication success\n
+SSH_AUTH_INFO:    The server asked some questions. Use
+                  auth_kbdint_getnprmopts() and such to retrieve
+                  and answer them.\n
+SSH_AUTH_AGAIN:   In nonblocking mode, you've got to call this again
+                  later.
+
+=item auth_kbdint_getname ([ OPTIONS ])
+
+Get the "name" of the message block. Returns undef if there isn't one or it couldn't be retrieved.
+
+=item auth_kbdint_getinstruction ([ OPTIONS ])
+
+Get the "instruction" of the message block. Returns undef if there isn't one or it couldn't be retrieved.
+
+=item auth_kbdint_getnprmopts ([ OPTIONS ])
+
+Get the number of authentication questions given by the server. This function can be used once you've called auth_kbdint() and the server responded with SSH_AUTH_INFO.
+
+=item auth_kbdint_getprompt ([ OPTIONS ])
+
+Get a prompt from a message block. This function can be used once you've called auth_kbdint() and the server responded with SSH_AUTH_INFO to retrieve one of the authentication questions. The total number of quesitons can be retrieved with auth_kbdint_getnprmopts().
+
+C<OPTIONS> are passed in a hash like fashion, using key and value pairs. Possible options are:
+
+B<index> - The number of the prompt you want to retrieve.
+
+=item auth_kbdint_setanswer ([ OPTIONS ])
+
+Set the answer to a prompt from a message block.
+
+C<OPTIONS> are passed in a hash like fashion, using key and value pairs. Possible options are:
+
+B<index> - The number of the prompt you want to give an answer to.
+
+B<answer> - The answer to the question. If reading ipnut from <STDIN> make sure to chomp() and append a "\0" character, otherwise it doesn't seem to work.
+
+
 =item auth_none ([ OPTIONS ])
 
 Try to authenticate through the "none" method. returns SSH_AUTH_SUCCESS if it succeeds.

--- a/lib/Libssh/Session.pm
+++ b/lib/Libssh/Session.pm
@@ -456,23 +456,13 @@ sub auth_kbdint_getnprmopts {
 sub auth_kbdint_getname {
     my ($self, %options) = @_;
 
-    my $ret = ssh_userauth_kbdint_getname($self->{ssh_session});
-    if (!defined $ret) {
-        $self->set_err(msg => sprintf("failed to get the name of the keyboard interactive message block: %s", ssh_get_error_from_session($self->{ssh_session})));
-    }
-
-    return $ret;
+    return ssh_userauth_kbdint_getname($self->{ssh_session});
 }
 
 sub auth_kbdint_getinstruction {
     my ($self, %options) = @_;
 
-    my $ret = ssh_userauth_kbdint_getinstruction($self->{ssh_session});
-    if (!defined $ret) {
-        $self->set_err(msg => sprintf("failed to get the instruction of the keyboard interactive message block: %s", ssh_get_error_from_session($self->{ssh_session})));
-    }
-
-    return $ret;
+    return ssh_userauth_kbdint_getinstruction($self->{ssh_session});
 }
 
 sub auth_kbdint_getprompt {

--- a/lib/Libssh/Session.pm
+++ b/lib/Libssh/Session.pm
@@ -490,7 +490,7 @@ sub auth_kbdint_setanswer {
     my ($self, %options) = @_;
 
     my $ret = ssh_userauth_kbdint_setanswer($self->{ssh_session}, $options{index}, $options{answer});
-    if ($ret) {
+    if ($ret < 0) {
         $self->set_err(msg => sprintf("failed to set an answer for a question from a keyboard interactive message block: %s", ssh_get_error_from_session($self->{ssh_session})));
     }
 

--- a/lib/Libssh/Session.pm
+++ b/lib/Libssh/Session.pm
@@ -446,7 +446,7 @@ sub auth_kbdint_getnprmopts {
     my ($self, %options) = @_;
 
     my $ret = ssh_userauth_kbdint_getnprompts($self->{ssh_session});
-    if ($ret == SSH_AUTH_ERROR) {
+    if ($ret == SSH_ERROR) {
         $self->set_err(msg => sprintf("failed to get number of keyboard interactive prompts: %s", ssh_get_error_from_session($self->{ssh_session})));
     }
 

--- a/lib/Libssh/Session.pm
+++ b/lib/Libssh/Session.pm
@@ -430,6 +430,73 @@ sub auth_none {
     return $ret;
 }
 
+sub auth_kbdint {
+    my ($self, %options) = @_;
+
+    my $ret = ssh_userauth_kbdint($self->{ssh_session});
+    if ($ret == SSH_AUTH_ERROR) {
+        $self->set_err(msg => sprintf("authentification failed: %s", ssh_get_error_from_session($self->{ssh_session})));
+    }
+    $self->{authenticated} = 1 if ($ret == SSH_OK);
+
+    return $ret;
+}
+
+sub auth_kbdint_getnprmopts {
+    my ($self, %options) = @_;
+
+    my $ret = ssh_userauth_kbdint_getnprompts($self->{ssh_session});
+    if ($ret == SSH_AUTH_ERROR) {
+        $self->set_err(msg => sprintf("failed to get number of keyboard interactive prompts: %s", ssh_get_error_from_session($self->{ssh_session})));
+    }
+
+    return $ret;
+}
+
+sub auth_kbdint_getname {
+    my ($self, %options) = @_;
+
+    my $ret = ssh_userauth_kbdint_getname($self->{ssh_session});
+    if (!defined $ret) {
+        $self->set_err(msg => sprintf("failed to get the name of the keyboard interactive message block: %s", ssh_get_error_from_session($self->{ssh_session})));
+    }
+
+    return $ret;
+}
+
+sub auth_kbdint_getinstruction {
+    my ($self, %options) = @_;
+
+    my $ret = ssh_userauth_kbdint_getinstruction($self->{ssh_session});
+    if (!defined $ret) {
+        $self->set_err(msg => sprintf("failed to get the instruction of the keyboard interactive message block: %s", ssh_get_error_from_session($self->{ssh_session})));
+    }
+
+    return $ret;
+}
+
+sub auth_kbdint_getprompt {
+    my ($self, %options) = @_;
+
+    my $ret = ssh_userauth_kbdint_getprompt($self->{ssh_session}, $options{index});
+    if (!defined $ret) {
+        $self->set_err(msg => sprintf("failed to get a prompt from a keyboard interactive message block: %s", ssh_get_error_from_session($self->{ssh_session})));
+    }
+
+    return $ret;
+}
+
+sub auth_kbdint_setanswer {
+    my ($self, %options) = @_;
+
+    my $ret = ssh_userauth_kbdint_setanswer($self->{ssh_session}, $options{index}, $options{answer});
+    if ($ret) {
+        $self->set_err(msg => sprintf("failed to set an answer for a question from a keyboard interactive message block: %s", ssh_get_error_from_session($self->{ssh_session})));
+    }
+
+    return $ret;
+}
+
 sub get_fd {
     my ($self, %options) = @_;
     

--- a/libssh.xs
+++ b/libssh.xs
@@ -159,6 +159,47 @@ ssh_userauth_none(ssh_session session)
         RETVAL = ssh_userauth_none(session, NULL);
     OUTPUT: RETVAL
 
+## Keyboard-interactive auth
+
+int
+ssh_userauth_kbdint(ssh_session session)
+    CODE:
+        RETVAL = ssh_userauth_kbdint(session, NULL, NULL);
+    OUTPUT: RETVAL
+
+int
+ssh_userauth_kbdint_getnprompts(ssh_session session)
+    CODE:
+        RETVAL = ssh_userauth_kbdint_getnprompts(session);
+    OUTPUT: RETVAL
+
+const char *
+ssh_userauth_kbdint_getname(ssh_session session)
+    CODE:
+        RETVAL = ssh_userauth_kbdint_getname(session);
+    OUTPUT: RETVAL
+
+const char *
+ssh_userauth_kbdint_getinstruction(ssh_session session)
+    CODE:
+        RETVAL = ssh_userauth_kbdint_getinstruction(session);
+    OUTPUT: RETVAL
+
+const char *
+ssh_userauth_kbdint_getprompt(ssh_session session, unsigned int i)
+    CODE:
+        RETVAL = ssh_userauth_kbdint_getprompt(session, i, NULL);
+    OUTPUT:
+        RETVAL
+
+int
+ssh_userauth_kbdint_setanswer(ssh_session session, unsigned int i, const char *answer)
+    CODE:
+        RETVAL = ssh_userauth_kbdint_setanswer(session, i, answer);
+    OUTPUT: RETVAL
+
+##
+
 int
 ssh_userauth_gssapi(ssh_session session)
     CODE:

--- a/libssh.xs
+++ b/libssh.xs
@@ -173,16 +173,32 @@ ssh_userauth_kbdint_getnprompts(ssh_session session)
         RETVAL = ssh_userauth_kbdint_getnprompts(session);
     OUTPUT: RETVAL
 
-const char *
+SV *
 ssh_userauth_kbdint_getname(ssh_session session)
     CODE:
-        RETVAL = ssh_userauth_kbdint_getname(session);
+        SV *ret;
+        const char *name;
+
+        name = ssh_userauth_kbdint_getname(session);
+        ret = &PL_sv_undef;
+        if (name != NULL && strlen(name) > 0) {
+            ret = newSVpv((char *)name, strlen((char *)name));
+        }
+        RETVAL = ret;
     OUTPUT: RETVAL
 
-const char *
+SV *
 ssh_userauth_kbdint_getinstruction(ssh_session session)
     CODE:
-        RETVAL = ssh_userauth_kbdint_getinstruction(session);
+        SV *ret;
+        const char *instruction;
+
+        instruction = ssh_userauth_kbdint_getinstruction(session);
+        ret = &PL_sv_undef;
+        if (instruction != NULL && strlen(instruction) > 0) {
+            ret = newSVpv((char *)instruction, strlen((char *)instruction));
+        }
+        RETVAL = ret;
     OUTPUT: RETVAL
 
 HV *

--- a/libssh.xs
+++ b/libssh.xs
@@ -189,8 +189,7 @@ const char *
 ssh_userauth_kbdint_getprompt(ssh_session session, unsigned int i)
     CODE:
         RETVAL = ssh_userauth_kbdint_getprompt(session, i, NULL);
-    OUTPUT:
-        RETVAL
+    OUTPUT: RETVAL
 
 int
 ssh_userauth_kbdint_setanswer(ssh_session session, unsigned int i, const char *answer)

--- a/libssh.xs
+++ b/libssh.xs
@@ -185,10 +185,21 @@ ssh_userauth_kbdint_getinstruction(ssh_session session)
         RETVAL = ssh_userauth_kbdint_getinstruction(session);
     OUTPUT: RETVAL
 
-const char *
+HV *
 ssh_userauth_kbdint_getprompt(ssh_session session, unsigned int i)
     CODE:
-        RETVAL = ssh_userauth_kbdint_getprompt(session, i, NULL);
+        HV *hv_ret = newHV();
+        const char *prompt;
+        char echo;
+
+        prompt = ssh_userauth_kbdint_getprompt(session, i, &echo);
+        (void)hv_store(hv_ret, "text", 4, newSVpv(prompt, strlen(prompt)), 0);
+        if (echo) {
+            (void)hv_store(hv_ret, "echo", 4, newSViv(1), 0);
+        } else {
+            (void)hv_store(hv_ret, "echo", 4, newSViv(0), 0);
+        }
+        RETVAL = hv_ret;
     OUTPUT: RETVAL
 
 int


### PR DESCRIPTION
Hi,

So as the title says I tried to make the wrapper compatible with the keyboard-interactive authentication method, but there are some things that worry me about my change and I would like another opinion. They are mostly related to XS because these are my first attempts at wrapping C code in Perl using it. So:

1) The function 'ssh_userauth_kbdint_getprompt' accepts an optional output parameter 'char * echo'. It is used to notify the SSH client if the user's input/answer to this prompt should be echoed on the terminal. For example it shouldn't be echoed for passwords. I completely failed at figuring out a way to return this optional char * paramater that can hold either '1' or '0' to the Perl so it can be used as a bool. For the time being I'm ignoring it and I pass NULL, but can you suggest a way to expose it?

2) The wrapped methods 'ssh_userauth_kbdint_getname' and 'ssh_userauth_kbdint_getinstruction' return nothing when I'm testing my code locally. The value is defined but is an empty string. That's why you can see in the client_kbdint_auth.pl example I'm not checking for their definedness. I'm guessing my SSH server sets the 'name' and 'instruction' for the ssh_kbdint struct to empty strings. Do you think it'll be a better idea to make these XSUBs return 'undef' instead of an empty string?

3) Not XS related. What's the logic behind using SSH_OK instead of SSH_AUTH_SUCCESS? For example in the Session::auth_password sub it is checked check if the rc is SSH_OK but in the example client_auth.pl the return code is compared to SSH_AUTH_SUCCESS? Both constants have the same value but still I'm not sure what to use when.

What's your general opinion on my pull request?