### PR TITLE
Improves docu for auth_kbdint_getprompt and example

### DIFF
--- a/examples/client_kbdint_auth.pl
+++ b/examples/client_kbdint_auth.pl
@@ -6,8 +6,8 @@ use Libssh::Session qw(:all);
 
 my $ssh_host = "127.0.0.1";
 my $ssh_port = 22;
-my $ssh_user = "sshtest";
-my $ssh_pass = "libsshtest";
+my $ssh_user = "root";
+my $ssh_pass = "centreon";
 
 my $session = Libssh::Session->new();
 if ($session->options(host => $ssh_host, port => $ssh_port, user => $ssh_user) != SSH_OK) {

--- a/lib/Libssh/Session.pm
+++ b/lib/Libssh/Session.pm
@@ -940,15 +940,15 @@ Get the number of authentication questions given by the server. This function ca
 
 Get a prompt from a message block. This function can be used once you've called auth_kbdint() and the server responded with SSH_AUTH_INFO to retrieve one of the authentication questions. The total number of quesitons can be retrieved with auth_kbdint_getnprmopts(). Returns a reference to a hash table.
 
+C<OPTIONS> are passed in a hash like fashion, using key and value pairs. Possible options are:
+
+B<index> - The number of the prompt you want to retrieve.
+
 The hash table returned has the following attributes:
 
 B<text> - The prompt text.
 
 B<echo> - '0' or '1' bool value whether or not the user's input should be echoed back.
-
-C<OPTIONS> are passed in a hash like fashion, using key and value pairs. Possible options are:
-
-B<index> - The number of the prompt you want to retrieve.
 
 =item auth_kbdint_setanswer ([ OPTIONS ])
 

--- a/lib/Libssh/Session.pm
+++ b/lib/Libssh/Session.pm
@@ -938,7 +938,13 @@ Get the number of authentication questions given by the server. This function ca
 
 =item auth_kbdint_getprompt ([ OPTIONS ])
 
-Get a prompt from a message block. This function can be used once you've called auth_kbdint() and the server responded with SSH_AUTH_INFO to retrieve one of the authentication questions. The total number of quesitons can be retrieved with auth_kbdint_getnprmopts().
+Get a prompt from a message block. This function can be used once you've called auth_kbdint() and the server responded with SSH_AUTH_INFO to retrieve one of the authentication questions. The total number of quesitons can be retrieved with auth_kbdint_getnprmopts(). Returns a reference to a hash table.
+
+The hash table returned has the following attributes:
+
+B<text> - The prompt text.
+
+B<echo> - '0' or '1' bool value whether or not the user's input should be echoed back.
 
 C<OPTIONS> are passed in a hash like fashion, using key and value pairs. Possible options are:
 


### PR DESCRIPTION
Hi,

I forgot to return the user credentials back to the ones used for the other examples. Probably in the future they can be refactored to accept cmd line values and/or interactively collect the user input.

Also improved the documentation for the auth_kbdint_getprompt to show what the returned hash contains.